### PR TITLE
Bugfix 19: Arithmetic overflow prevention

### DIFF
--- a/Anzurio.Rational.Tests/RationalNumberConstruction.cs
+++ b/Anzurio.Rational.Tests/RationalNumberConstruction.cs
@@ -34,8 +34,8 @@ namespace Anzurio.Rational.Tests
             int wholeNumber, 
             int numerator, 
             int denominator,
-            int expectedNumerator,
-            int expectedDenominator)
+            long expectedNumerator,
+            long expectedDenominator)
         {
             var rationalNumber = new RationalNumber(wholeNumber, numerator, denominator);
             rationalNumber.Denominator.Should().Be(expectedDenominator);
@@ -58,8 +58,8 @@ namespace Anzurio.Rational.Tests
         public void ConstructRationalNumber(
             int numerator,
             int denominator,
-            int expectedNumerator,
-            int expectedDenominator)
+            long expectedNumerator,
+            long expectedDenominator)
         {
             var rationalNumber = new RationalNumber(numerator, denominator);
             rationalNumber.Denominator.Should().Be(expectedDenominator);
@@ -67,7 +67,7 @@ namespace Anzurio.Rational.Tests
         }
 
         [TestCase]
-        public void AttemptToConstructNotANumberRationalNumber()
+        public void AttemptToConstructARationalNumberWithDenominatorZeroShouldThrowNotARationalNumber()
         {
             Action createNotANumberRational = () => new RationalNumber(1, 0);
             Action createNotANumberRationalWithWholeNumber = () => new RationalNumber(0, 1, 0);
@@ -81,7 +81,7 @@ namespace Anzurio.Rational.Tests
         [TestCase(-1, 1, -1)]
         [TestCase(-1, -1, 1)]
         [TestCase(-1, -1, -1)]
-        public void AttemptToConstructInvalidRationalNumberByRepeatedMinusSign(
+        public void AttemptToConstructInvalidRationalNumberByRepeatedMinusSignShouldThrowInvalidRationalNumber(
             int numerator,
             int denominator,
             int? wholeNumber)

--- a/Anzurio.Rational.Tests/SolveArithmeticStringExpression.cs
+++ b/Anzurio.Rational.Tests/SolveArithmeticStringExpression.cs
@@ -16,7 +16,7 @@ namespace Anzurio.Rational.Tests
         [TestCase("-2/3 / 0/1")]
         [TestCase("3 / 0_0/1")]
         [TestCase("-1_1/1 / -0_0/1")]
-        public void AttemptToDivideByZero(string expression)
+        public void AttemptToDivideByZeroShouldThrowDivideByZeroException(string expression)
         {
             Func<RationalNumber> fx = () => RationalNumber.SolveArithmeticExpression(expression);
             fx.Should().Throw<DivideByZeroException>();
@@ -39,7 +39,7 @@ namespace Anzurio.Rational.Tests
         [TestCase("1/0")]
         [TestCase("A00")]
         [TestCase("00A")]
-        public void AttemptToSolveWithInvalidOperand(string operand)
+        public void AttemptToSolveWithInvalidOperandShouldThrowInvalidOperationException(string operand)
         {
             foreach (var op in Operators)
             {
@@ -57,7 +57,7 @@ namespace Anzurio.Rational.Tests
         [TestCase("3- 3")]
         [TestCase("3 * 4 - 4")]
         [TestCase("something")]
-        public void AttemptToSolveAnInvalidExpression(string expression)
+        public void AttemptToSolveAnInvalidExpressionShouldThrowInvalidOperationException(string expression)
         {
             Func<RationalNumber> fx = () => RationalNumber.SolveArithmeticExpression(expression);
             fx.Should().Throw<InvalidOperationException>();
@@ -152,11 +152,34 @@ namespace Anzurio.Rational.Tests
         [TestCase("1/7 -      -1/5", "12/35")]
         [TestCase("10_1/10 - 1_5/10", "8_3/5")]
         [TestCase("10_1/10 - -1_5/10", "11_3/5")]
+        [TestCase("2147483647 + 1", "2147483648")]
+        [TestCase("-2147483648 - 1", "-2147483649")]
+        [TestCase("2147483647 * 2147483647/2147483647", "2147483647")]
+        [TestCase("-2147483648 * -2147483647/2147483647", "2147483648")]
+        [TestCase("2147483647 * -2147483647/2147483647", "-2147483647")]
+        [TestCase("2147483647 / 2147483647/2147483647", "2147483647")]
+        [TestCase("-2147483648 / -2147483647/2147483647", "2147483648")]
+        [TestCase("2147483647 / -2147483647/2147483647", "-2147483647")]
+        [TestCase("2147483647 * -2", "-4294967294")]
+        [TestCase("-2147483648 / 1/2", "-4294967296")]
         public void SolveValidExpression(string expression, string desiredOutput)
         {
             RationalNumber.SolveArithmeticExpression(expression).ToString()
                 .Should()
                 .Be(desiredOutput);
+        }
+
+        [TestCase("2147483647 + 1")]
+        [TestCase("-2147483648 - 1")]
+        [TestCase("2147483647 * 2147483647/1")]
+        [TestCase("-2147483648 * -2147483647/1")]
+        [TestCase("2147483647 * -2147483647/1")]
+        [TestCase("-2147483648 / 1/2")]
+        [TestCase("2147483647 / 1/2")]
+        public void AttemptToSolveRationalNumberExpressionWhoseResultIsOutsideInt32LimitsShouldNotThrow(string expression)
+        {
+            Func<RationalNumber> fx = () => RationalNumber.SolveArithmeticExpression(expression);
+            fx.Should().NotThrow();
         }
     }
 }

--- a/Anzurio.Rational.Tests/StringParsingAsRationalNumber.cs
+++ b/Anzurio.Rational.Tests/StringParsingAsRationalNumber.cs
@@ -32,6 +32,8 @@ namespace Anzurio.Rational.Tests
         [TestCase("-5", "-5")]
         [TestCase("2", "2")]
         [TestCase("-0", "0")]
+        [TestCase("-2147483648", "-2147483648")]
+        [TestCase("2147483647", "2147483647")]
         public void ConstructFractionFromStringParsing(string rationalNumber, string expectedResult)
         {
             var isValidFractionString = RationalNumber.TryParse(rationalNumber, out RationalNumber result);
@@ -62,7 +64,7 @@ namespace Anzurio.Rational.Tests
         }
 
         [TestCase]
-        public void ParseANullStringAsARationalNumber()
+        public void ParsingANullStringAsARationalNumberShouldThrowArgumentNullException()
         {
             Action action = () => RationalNumber.Parse(null);
             action.Should().Throw<ArgumentNullException>();
@@ -85,7 +87,7 @@ namespace Anzurio.Rational.Tests
         [TestCase("7_")]
         [TestCase("7_/8")]
         [TestCase("/8")]
-        public void ParseAnInvalidFormatStringAsARationalNumber(string rationalNumber)
+        public void ParsingAnInvalidFormatStringAsARationalNumberShouldThrowFormatException(string rationalNumber)
         {
             Action action = () => RationalNumber.Parse(rationalNumber);
             action.Should().Throw<FormatException>();
@@ -95,10 +97,22 @@ namespace Anzurio.Rational.Tests
         [TestCase("1_1/0")]
         [TestCase("5/0")]
         [TestCase("-1/0")]
-        public void ParseAnInvalidRationalNumberString(string rationalNumber)
+        public void ParsingARationalNumberWithDenominatorZeroStringShouldThrowNotARationalNumberException(string rationalNumber)
         {
             Action action = () => RationalNumber.Parse(rationalNumber);
             action.Should().Throw<NotARationalNumberException>();
+        }
+
+        [TestCase("-2147483649")]
+        [TestCase("2147483648")]
+        [TestCase("-1/2147483648")]
+        [TestCase("1/2147483648")]
+        [TestCase("-2147483649_1/2")]
+        [TestCase("2147483648_1/2")]
+        public void ParsingAnOutOfBoundsRationalStringShouldThrowOverflowException(string rationalNumber)
+        {
+            Action action = () => RationalNumber.Parse(rationalNumber);
+            action.Should().Throw<OverflowException>();
         }
     }
 }

--- a/Anzurio.Rational/RationalNumber.cs
+++ b/Anzurio.Rational/RationalNumber.cs
@@ -28,11 +28,11 @@ namespace Anzurio.Rational
         /// <summary>
         /// The numerator of the rational number.
         /// </summary>
-        public int Numerator { get; internal set; }
+        public long Numerator { get; internal set; }
         /// <summary>
         /// The denominator of the rational number.
         /// </summary>
-        public int Denominator { get; internal set; }
+        public long Denominator { get; internal set; }
 
         /// <summary>
         /// Creates a RationalNumber by providing a whole number (which may be zero) and a fraction.
@@ -43,6 +43,12 @@ namespace Anzurio.Rational
         /// <exception cref="NotARationalNumberException"><paramref name="denominator"/> is zero.</exception>
         /// <exception cref="InvalidRationalNumber">More than one of the parameters is negative.</exception>
         public RationalNumber(int whole, int numerator, int denominator)
+            : this((long)whole, (long)numerator, (long)denominator)
+        {
+
+        }
+
+        private RationalNumber(long whole, long numerator, long denominator)
         {
             if (denominator == 0)
             {
@@ -56,7 +62,7 @@ namespace Anzurio.Rational
             whole = Math.Abs(whole);
             numerator = Math.Abs(numerator);
             denominator = Math.Abs(denominator);
-            
+
             numerator += (whole * denominator);
             var greatestCommonFactor = CalculateGreatestCommonFactor(numerator, denominator);
             greatestCommonFactor = greatestCommonFactor == 0 ? 1 : greatestCommonFactor;
@@ -78,11 +84,17 @@ namespace Anzurio.Rational
 
         }
 
+        private RationalNumber(long numerator, long denominator)
+            : this(0, numerator, denominator)
+        {
+
+        }
+
         /// <summary>
         /// Creates a RationalNumber by providing a whole number.
         /// </summary>
         /// <param name="whole">A whole number.</param>
-        public RationalNumber(int whole) 
+        public RationalNumber(int whole)
             : this(whole, 1)
         {
 
@@ -135,7 +147,8 @@ namespace Anzurio.Rational
         {
             ValidateOperandsNotNullOrThrow(lhs, rhs);
             
-            return new RationalNumber(lhs.Numerator * rhs.Numerator, lhs.Denominator * rhs.Denominator);
+            return new RationalNumber(
+                checked(lhs.Numerator * rhs.Numerator), checked(lhs.Denominator * rhs.Denominator));
         }
 
         /// <summary>
@@ -156,8 +169,8 @@ namespace Anzurio.Rational
             var areBothSidesNegative = lhs.Numerator < 0 && rhs.Numerator < 0;
 
             return new RationalNumber(
-                lhs.Numerator * rhs.Denominator * (areBothSidesNegative ? -1 : 1), 
-                lhs.Denominator * rhs.Numerator * (areBothSidesNegative ? -1 : 1));
+                checked(lhs.Numerator * rhs.Denominator * (areBothSidesNegative ? -1 : 1)), 
+                checked(lhs.Denominator * rhs.Numerator * (areBothSidesNegative ? -1 : 1)));
         }
 
         /// <summary>
@@ -171,8 +184,8 @@ namespace Anzurio.Rational
         {
             ValidateOperandsNotNullOrThrow(lhs, rhs);
             return new RationalNumber(
-                (lhs.Numerator * rhs.Denominator) + (lhs.Denominator * rhs.Numerator),
-                lhs.Denominator * rhs.Denominator);
+                checked((lhs.Numerator * rhs.Denominator) + (lhs.Denominator * rhs.Numerator)),
+                checked(lhs.Denominator * rhs.Denominator));
         }
 
         /// <summary>
@@ -186,8 +199,8 @@ namespace Anzurio.Rational
         {
             ValidateOperandsNotNullOrThrow(lhs, rhs);
             return new RationalNumber(
-                (lhs.Numerator * rhs.Denominator) - (lhs.Denominator * rhs.Numerator),
-                lhs.Denominator * rhs.Denominator);
+                checked((lhs.Numerator * rhs.Denominator) - (lhs.Denominator * rhs.Numerator)),
+                checked(lhs.Denominator * rhs.Denominator));
         }
 
         /// <summary>
@@ -202,7 +215,7 @@ namespace Anzurio.Rational
         /// <returns>A Rational Number equivalent to the fraction specified in <paramref name="s"/></returns>
         /// <exception cref="ArgumentNullException"><paramref name="s"/> is null.</exception>
         /// <exception cref="FormatException"><paramref name="s"/> is not in a correct format.</exception>
-        /// <exception cref="OverflowException">Any numeric element of <paramref name="s"/> is larger than the numeric bounds.</exception>
+        /// <exception cref="OverflowException">Any numeric element of <paramref name="s"/> is less than <see cref="Int32.MinValue"/> or greater than <see cref="Int32.MaxValue"/>.</exception>
         public static RationalNumber Parse(string s)
         {
             if (s == null)
@@ -251,7 +264,7 @@ namespace Anzurio.Rational
         /// <returns>The resulting value of performing the operation.</returns>
         /// <exception cref="InvalidOperationException">A valid operator is not present or not surrounded by spaces.</exception>
         /// <exception cref="FormatException">Either operand is not in a correct format.</exception>
-        /// <exception cref="OverflowException">Any numeric component of either operand is larger than the numeric bounds.</exception>
+        /// <exception cref="OverflowException">Any numeric component of either operand is less than <see cref="Int32.MinValue"/> or greater than <see cref="Int32.MaxValue"/>.</exception>
         /// <exception cref="DivideByZeroException">The right operand is equivalent to zero.</exception>
         public static RationalNumber SolveArithmeticExpression(string expression)
         {
@@ -289,7 +302,7 @@ namespace Anzurio.Rational
             }
         }
 
-        private static int CalculateGreatestCommonFactor(int numerator, int denominator)
+        private static long CalculateGreatestCommonFactor(long numerator, long denominator)
         {
             while (numerator != 0 && denominator != 0)
             {
@@ -360,7 +373,7 @@ namespace Anzurio.Rational
             return (leftOperand, rightOperand);
         }
 
-        private static int CountNegativeNumbers(IEnumerable<int> numbers)
+        private static int CountNegativeNumbers(IEnumerable<long> numbers)
         {
             return numbers.Count(n => n < 0);
         }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains a .NET Core command line program written in C# that wil
 
 ### Prerequistes
 
-In order to to run these projects, .NET Core 2.2 or newer **MUST** be installed in your computer along with the `dotnet` command line tool.
+In order to to run these projects, [.NET Core 2.2 or newer](https://dotnet.microsoft.com/download/dotnet-core) **MUST** be installed in your computer along with the `dotnet` command line tool.
 
 ### Running the Application
 

--- a/RationalNumberShell/Program.cs
+++ b/RationalNumberShell/Program.cs
@@ -80,7 +80,8 @@ namespace RationalNumberShell
             Console.WriteLine("Remarks:");
             Console.WriteLine("For consistency to other Parse methods in .NET-based shells, 0_0/3 and 0_1/3 are valid representations of a fractions (e.g., double.Parse(\"0.0\");)");
             Console.WriteLine("To avoid ambiguity, the minus sign to represent a negative number, must always be at the beginning of the fraction.");
-            Console.WriteLine("Using a whole number and an improper fraction is valid as  3_2/3 is mathematically equivalent to 3 + 2/3 thus so would be 3_4/3.</p>");
+            Console.WriteLine("Using a whole number and an improper fraction is valid as 3_2/3 is mathematically equivalent to 3 + 2/3 thus so would be 3_4/3.</p>");
+            Console.WriteLine($"Any numeric component of the fraction must be less than or equal to {Int32.MaxValue} and greater than or equal to {Int32.MinValue}.");
             Console.ResetColor();
         }
     }


### PR DESCRIPTION
By internally representing the `Numerator` and `Denominator` as `Int64` yet limit public construction to `Int32` we are able to seamlessly operate upon numbers (or results) that may otherwise overflow.

Closes #19 
